### PR TITLE
Fix API key filter NPE

### DIFF
--- a/src/main/java/com/mybankingapp/accountservices/config/ApiKeyFilter.java
+++ b/src/main/java/com/mybankingapp/accountservices/config/ApiKeyFilter.java
@@ -48,13 +48,15 @@ public class ApiKeyFilter extends OncePerRequestFilter {
 
         String apiKeyHeader = request.getHeader(API_KEY_HEADER);
 
-        if (apiKeyHeader == null) {
-            sendUnauthorizedResponse.sendUnauthorizedResponse(response, "Unauthorized: No API key found in request headers");
+        if (apiKeyHeader == null || API_KEY == null) {
+            sendUnauthorizedResponse.sendUnauthorizedResponse(response,
+                    "Unauthorized: No API key found in request headers");
             return;
         }
 
         if (!API_KEY.equals(apiKeyHeader)) {
-            sendUnauthorizedResponse.sendUnauthorizedResponse(response, "Unauthorized: Invalid API key");
+            sendUnauthorizedResponse.sendUnauthorizedResponse(response,
+                    "Unauthorized: Invalid API key");
             return;
         }
 


### PR DESCRIPTION
## Summary
- avoid NullPointerException when API_KEY property is missing

## Testing
- `./mvnw -q test` *(fails: cannot open `.mvn/wrapper/maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_683f72a0d3248328973c178a23269d11